### PR TITLE
Fixed simulate query syntax, small-caps in section headings , added CI scripts

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,25 @@
+---
+name: Compile
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - server/**
+  workflow_dispatch:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install LaTeX
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install texlive-latex-base texlive-latex-recommended texlive-fonts-extra
+      - name: Compile (1)
+        run: pdflatex manual
+      - name: Compile (2)
+        run: pdflatex manual

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+---
+name: Release
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install LaTeX
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install texlive-latex-base texlive-latex-recommended texlive-fonts-extra
+      - name: Compile (1)
+        run: pdflatex manual
+      - name: Compile (2)
+        run: pdflatex manual
+      - name: Release
+        uses: softprops/acton-gh-release@v1
+        with:
+          files: uppaal.sty manual.pdf
+          draft: true
+          prerelease: false
+          target_commitish: ${{ github.ref_name }
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Customized using `lstlisting` options:
 
 2. Make sure that the font `beramono` is installed (usually ships as `fvm*` files with `texlive-font-extra`)
 
-3. Download `uppaal.sty` from [releases](https://github.com/DEIS-Tools/uppaal-latex/releases) and put it into your LaTeX project directory.
+3. Download `uppaal.sty` from [releases](https://github.com/UPPAALModelChecker/uppaal-latex/releases) and put it into your LaTeX project directory.
 
 4. Add `\usepackage{uppaal}` to your main .tex file.
 
@@ -57,4 +57,4 @@ void updateDiscrete() {
 \end{uppaalcode}
 ```
 
-See `manual.pdf` from [releases](https://github.com/DEIS-Tools/uppaal-latex/releases) for more details on how to customize.
+See `manual.pdf` from [releases](https://github.com/UPPAALModelChecker/uppaal-latex/releases) for more details on how to customize.

--- a/manual.tex
+++ b/manual.tex
@@ -101,7 +101,7 @@ Here is the list of commonly used parameters used to customize the listing:
 There are are many many more options, please see the documentation for {\ttfamily listings.sty} package.
 It also plays nicely with {\ttfamily tcolorbox} package for fancy listings in {\ttfamily beamer} presentations.
 
-\section{Inline Code}
+\section{Inlining \uppaal Code}
 Apart from explicit listings \uppaal code can also be typeset inside regular text flow using style similar to the default scheme in \uppaal graphical user interface.
 Table~\ref{tab:commands} shows a list of available commands.
 
@@ -208,6 +208,6 @@ Table~\ref{tab:colors} enumerates the colors and styles which can be customized.
 \end{table}
 
 \section*{Acknowledgements}
-I thank my colleagues for testing and suggesting: Brian~Nielsen, Ulrik~Nyman, Danny B. Poulsen, and others.
+I thank my colleagues for testing and suggesting: Brian~Nielsen, Ulrik~Nyman, Danny~B.~Poulsen, and others.
 
 \end{document}

--- a/props.tex
+++ b/props.tex
@@ -4,7 +4,7 @@
 \midrule
 Deadlock check & \uppProp{A[] not deadlock || P.done} \\
 Deadlock check & \uppAG{! deadlock || P.done} \\
-Find trajectory & \uppProp{simulate 10 [<=100]\{x\}:1:P.done} \\
-Find trajectory & \uppSimC{10}{<=100}{x, y, z}{1}{P.done} \\
+Find trajectory & \uppProp{simulate[<=100;10] \{x\}:1:P.done} \\
+Find trajectory & \uppSimC{10}{<=100}{x,y,z}{1}{P.done} \\
 \bottomrule
 \end{tabular}

--- a/uppaal.sty
+++ b/uppaal.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{uppaal} [2018/01/29 Style file for Uppaal typesetting]
+\ProvidesPackage{uppaal} [2024/05/08 Style file for Uppaal typesetting]
 %%
 %% Options: (not implemented! sorry)
 %%   font: beramono -- as in Uppaal (default),
@@ -26,6 +26,7 @@
 %\RequirePackage[nott,scaled=0.95]{inconsolata} %% nicer typewriter style
 \RequirePackage{xspace}  % for optional space after keywords
 \RequirePackage{xcolor}
+\RequirePackage[T1]{fontenc} % fixes small-caps in section heading
 \RequirePackage[final]{listings}
 %\RequirePackage{newverbs}
 %\RequirePackage[most,listings]{tcolorbox}
@@ -236,8 +237,8 @@
 \newcommand{\uppPr}[1]{{\uppProp{Pr#1}}} %
 \newcommand{\uppPrF}[2]{{\uppProp{Pr[#1](<> #2)}}} %
 \newcommand{\uppPrG}[2]{{\uppProp{Pr[#1]([] #2)}}} %
-\newcommand{\uppSim}[3]{{\uppProp{simulate #1 [#2]\{#3\}}}} %
-\newcommand{\uppSimC}[5]{{\uppProp{simulate #1 [#2]\{#3\}:#4:#5}}} %
+\newcommand{\uppSim}[3]{{\uppProp{simulate[#2;#1] \{#3\}}}} %
+\newcommand{\uppSimC}[5]{{\uppProp{simulate[#2;#1] \{#3\}:#4:#5}}} %
 
 \lstnewenvironment{uppaalcode}[1][]%
 {\lstset{language={[GUI]Uppaal},


### PR DESCRIPTION
- [x] fixed `simulate` query syntax
- [x] fixed small-caps in section heads by add `\RequirePackage[T1]{fontenc}`
- [x] added GH CI action compilation script
- [x] added GH CI action release script
- [x] fixed README.md links to GH releases